### PR TITLE
Fix/estimate max send

### DIFF
--- a/src/Insight.ts
+++ b/src/Insight.ts
@@ -98,7 +98,7 @@ export class Insight {
       return feeRate
     }
 
-    return Math.ceil(feeRate / 1024)
+    return Math.ceil(feeRate / 1000)
   }
 
   /**

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -275,7 +275,7 @@ export class Wallet {
       pos: uxto.vout,
       value: uxto.satoshis,
       hash: uxto.txid,
-    })).filter((utxo) => utxo.confirmations >= 500 || !utxo.isStake)
+    })).filter((utxo) => utxo.confirmations >= 2000 || !utxo.isStake)
 
     return bitcoinjsUTXOs
   }

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -24,7 +24,7 @@ import { params, IScryptParams } from "./scrypt"
  *
  * This value will be used for testnet.
  */
-const defaultTxFeePerByte = Math.ceil((0.004 * 1e8) / 1000)
+const defaultTxFeePerByte = Math.ceil((0.005 * 1e8) / 1000)
 
 export class Wallet {
   public address: string

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -24,7 +24,7 @@ import { params, IScryptParams } from "./scrypt"
  *
  * This value will be used for testnet.
  */
-const defaultTxFeePerByte = Math.ceil((0.004 * 1e8) / 1024)
+const defaultTxFeePerByte = Math.ceil((0.004 * 1e8) / 1000)
 
 export class Wallet {
   public address: string

--- a/src/tx.ts
+++ b/src/tx.ts
@@ -388,7 +388,7 @@ export function buildSendToContractTransaction(
 }
 
 // The prevalent network fee is 0.004 per KB. If set to 100 times of norm, assume error.
-const MAX_FEE_RATE = Math.ceil((0.004 * 100 * 1e8) / 1024)
+const MAX_FEE_RATE = Math.ceil((0.004 * 100 * 1e8) / 1000)
 
 function checkFeeRate(feeRate: number) {
   if (feeRate > MAX_FEE_RATE) {


### PR DESCRIPTION
Update fee calculations in order to correctly calculate the max value of QTUM to send from QiWallet: 
	- 1000 bytes/KB instead of 1024 (which is is used in BTC)
	- Update UTXO's confirmation limit from 500 to 2000 
	- Update testnet default tx fee from 400 to 500 

